### PR TITLE
Use Black style with isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/dan-knight/hiddenfb"
 Issues = "https://github.com/dan-knight/hiddenfb/issues"
+
+[tool.isort]
+profile = "black"

--- a/tests/unit/database/ETL/metrica/file_loader/test_metrica_tracking_file_loader.py
+++ b/tests/unit/database/ETL/metrica/file_loader/test_metrica_tracking_file_loader.py
@@ -4,11 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 from unittest.mock import mock_open, patch
 
-# fmt: off
-from hiddenfb.database.ETL.metrica.file_loader.tracking import \
-    MetricaTrackingLoader
-
-# fmt: on
+from hiddenfb.database.ETL.metrica.file_loader.tracking import MetricaTrackingLoader
 
 
 def test__metrica_tracking_loader__loads_valid_format():


### PR DESCRIPTION
Avoids linting conflicts between isort and Black's style preferences. Black is more opinionated, so it will take priority.