### PR TITLE
Base repository classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Domain models for basic tracking and event data
 - Utilities to load data files
 - Utilities to validate Wyscout and Metrica event/tracking data
+- Generic repository base classes
 
 ## [0.0.1] - 2024-01-28
 

--- a/hiddenfb/database/repository/__init__.py
+++ b/hiddenfb/database/repository/__init__.py
@@ -1,0 +1,23 @@
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+from hiddenfb.utility.file_loader import FileLoader
+
+
+ModelType = TypeVar("ModelType")
+StoreType = TypeVar("StoreType")
+
+
+class Repository(Generic[ModelType, StoreType], ABC):
+    @abstractmethod
+    def _to_model(self, stored: StoreType) -> ModelType:
+        ...
+    
+    @abstractmethod
+    def _from_model(self, model: ModelType) -> StoreType:
+        ...
+
+
+class FileRepository(Repository[ModelType, StoreType]):
+    def __init__(self, file_loader: FileLoader):
+        self._loader: FileLoader = file_loader

--- a/hiddenfb/database/repository/__init__.py
+++ b/hiddenfb/database/repository/__init__.py
@@ -3,19 +3,16 @@ from typing import Generic, TypeVar
 
 from hiddenfb.utility.file_loader import FileLoader
 
-
 ModelType = TypeVar("ModelType")
 StoreType = TypeVar("StoreType")
 
 
 class Repository(Generic[ModelType, StoreType], ABC):
     @abstractmethod
-    def _to_model(self, stored: StoreType) -> ModelType:
-        ...
-    
+    def _to_model(self, stored: StoreType) -> ModelType: ...
+
     @abstractmethod
-    def _from_model(self, model: ModelType) -> StoreType:
-        ...
+    def _from_model(self, model: ModelType) -> StoreType: ...
 
 
 class FileRepository(Repository[ModelType, StoreType]):


### PR DESCRIPTION
Sets up basic repository design. Currently treats all objects as value objects - does not include any handling of entities. This added complexity is not necessary at this point, so it can be deferred.